### PR TITLE
Fix styling when used with folder icons

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,9 @@ export default class FrontmatterAliasDisplay extends Plugin {
 				let alias = app.metadataCache.getFileCache(file.file)?.frontmatter?.alias;
 
                 let aliasContent = alias ? alias : aliases;
-				file.selfEl.createEl('div', {text: aliasContent, cls: 'file-alias nav-file-title-content'});
+				if ( aliasContent ) {
+				    file.selfEl.createEl('div', {text: aliasContent, cls: 'file-alias nav-file-title-content'});
+				}
 			}
 		}
 	}

--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,8 @@
 .nav-file-title {
-    display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
 }
 
 .file-alias {
+    flex: 0 0 100%;
     font-size: 12px;
-    font-weight: bold;
- }
-
- .nav-file-tag {
-    align-self: flex-start;
- }
+}


### PR DESCRIPTION
This PR fixes the styling in this plugin when used with other file explorer plugins such as those that add icons to each file. This was tested against Obsidian v1.3.7 and may correct other outstanding styling issues, though I have not had an opportunity to test those issues independently.

Thanks for the great plugin!